### PR TITLE
switched to alpine image for runtime build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN go mod vendor
 ENV CGO_ENABLED=0
 RUN GOOS=linux go build -mod vendor -a -o smtp2http .
 
-FROM golang:1.16.2  
+FROM alpine:latest
 WORKDIR /root/
 COPY --from=builder /go/src/build/smtp2http /usr/bin/smtp2http
 ENTRYPOINT ["smtp2http"]


### PR DESCRIPTION
In Dockerfile the (non-builder) image is based on 'golang' image rather than a smaller, simpler runtime image (eg alpine, Debian slim).

This patch replaces the golang image (1GB) with alpine image (20MB). Go builds a static binary for smtp2http so alpine's unusual libc isn't a problem.

Hope this helps. Sorry if I've missed something - I'm new to go and docker.